### PR TITLE
Enable Gradio share mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,4 +17,4 @@ with gr.Blocks() as demo:
     generate_btn.click(generate_image, inputs=[prompt, negative_prompt], outputs=output)
 
 if __name__ == "__main__":
-    demo.launch()
+    demo.launch(share=True)


### PR DESCRIPTION
## Summary
- enable Gradio sharing by default

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684f0eb7d2408333ba4101d41ee5e62a