### PR TITLE
Improve pipeline error handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,13 +46,25 @@ def get_pipeline(model_name):
         if repo is None:
             raise ValueError(f"Unknown model: {model_name}")
         if model_name == "sdxl":
-            pipe = DiffusionPipeline.from_pretrained(
-                repo, torch_dtype=torch.float16, variant="fp16"
-            )
+            try:
+                pipe = DiffusionPipeline.from_pretrained(
+                    repo, torch_dtype=torch.float16, variant="fp16"
+                )
+            except ImportError as e:
+                raise RuntimeError(
+                    "StableDiffusionXLPipeline requires the 'transformers' library. "
+                    "Install it with `pip install transformers`."
+                ) from e
         else:
-            pipe = StableDiffusionPipeline.from_pretrained(
-                repo, torch_dtype=torch.float16
-            )
+            try:
+                pipe = StableDiffusionPipeline.from_pretrained(
+                    repo, torch_dtype=torch.float16
+                )
+            except ImportError as e:
+                raise RuntimeError(
+                    "StableDiffusionPipeline requires the 'transformers' library. "
+                    "Install it with `pip install transformers`."
+                ) from e
         device = "cuda" if torch.cuda.is_available() else "cpu"
         pipe.to(device)
         PIPELINES[model_name] = pipe

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ fastapi
 uvicorn
 diffusers
 torch
+transformers


### PR DESCRIPTION
## Summary
- handle missing `transformers` library when loading pipelines
- add `transformers` to dependencies

## Testing
- `python -m py_compile app.py scripts/analyze_data.py`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684f17a94bb88333a5732b7c12dd9f3a