### PR TITLE
Add preset models and local model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,26 @@ controls for seed, steps and resolution. The app can list models and LoRA files
 from the `models/` and `loras/` folders and displays generated images in a
 gallery.
 
+## Available Models
+
+Built-in presets are provided for several Hugging Face models. Any model files
+placed in the `models/` folder (e.g. `.safetensors` or `.ckpt`) are also offered
+in the selector.
+
+| Modelltyp | Modell (Hugging Face) | Besonderheiten |
+| --------- | --------------------- | -------------- |
+| **SD 1.5** | SG161222/Realistic_Vision_V6 | Fotorealistisch, sehr beliebt |
+| | XpucT/Deliberate | Detailreich & kreativ |
+| | fluently/Fluently-v4 | Vielseitig & ästhetisch |
+| **SDXL** | fluently/Fluently‑XL‑Final | Hoch frequentiert, stabil |
+| | SG161222/RealVisXL_V4.0 | Prompt-treu & qualitativ |
+| | ehristoforu/Visionix-alpha | Trendmodell |
+| | Halcyon 1.7 | Reddit-Topwahl für Details |
+| | SDXL-Lightning | Schnellverfahren mit guter Qualität |
+| **PonyXL** | glides/ponyxl | Gute Basis für Pferde |
+| | LyliaEngine/Pony Diffusion V6 XL | Anthro/SFW & NSFW flexibel |
+| | John6666/damn-ponyxl-realistic-v3-sdxl | Fotorealistische Pferde |
+
 ## Setup
 
 1. Install dependencies:


### PR DESCRIPTION
## Summary
- expand predefined model list with additional SD 1.5, SDXL and PonyXL presets
- show models found in the `models/` folder
- support loading models from local files or folders
- document available models in README

## Testing
- `python -m py_compile app.py scripts/analyze_data.py`

------
https://chatgpt.com/codex/tasks/task_e_684f20b856e88333bde7c7650438b9e7