### PR TITLE
Replace deprecated Box with Group

### DIFF
--- a/app.py
+++ b/app.py
@@ -175,7 +175,9 @@ with gr.Blocks() as demo:
             generate_btn = gr.Button("Generate")
 
         with gr.Column(scale=1):
-            with gr.Box():
+            # Box was removed in newer versions of Gradio; Group provides a
+            # simple container without padding/margin.
+            with gr.Group():
                 gr.Markdown("### Additional Settings")
                 nsfw_filter = gr.Checkbox(label="NSFW Filter", value=True)
                 images_per_batch = gr.Number(


### PR DESCRIPTION
## Summary
- use `gr.Group` instead of removed `gr.Box`

## Testing
- `python -m py_compile app.py`
- `python app.py` (terminated after launch)

------
https://chatgpt.com/codex/tasks/task_e_684f25e163f8833391d087503f0c8a9f