### PR TITLE
Fix pipeline loading for SDXL models

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,11 @@ import gradio as gr
 from PIL import Image
 import numpy as np
 import torch
-from diffusers import DiffusionPipeline, StableDiffusionPipeline
+from diffusers import (
+    DiffusionPipeline,
+    StableDiffusionPipeline,
+    StableDiffusionXLPipeline,
+)
 
 PRESETS_FILE = "presets.txt"
 
@@ -130,7 +134,7 @@ def get_pipeline(model_name):
 
         if "xl" in model_name.lower() or "xl" in repo.lower():
             try:
-                pipe = DiffusionPipeline.from_single_file(
+                pipe = StableDiffusionXLPipeline.from_single_file(
                     repo, torch_dtype=torch.float16, variant="fp16"
                 )
             except ImportError as e:


### PR DESCRIPTION
## Summary
- import StableDiffusionXLPipeline
- use StableDiffusionXLPipeline.from_single_file when loading SDXL models

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684f38b61dc08333813e6e1a76e91814