### PR TITLE
Add Model Manager sub tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 SDUnity is a self-hosted web interface built with [Gradio](https://www.gradio.app/) for generating and managing images with Stable Diffusion models. It combines model selection, LoRA management and an image gallery into a single application.
 
 The interface now features a modern dark theme for a sleeker look.
-The UI is organized into tabs for **Generation**, a placeholder **Model Manager**, and a **Gallery** of past results.
+The UI is organized into tabs for **Generation**, a **Model Manager** with subtabs for models and LoRAs, and a **Gallery** of past results.
 
 ## Features
 

--- a/app.py
+++ b/app.py
@@ -421,7 +421,21 @@ with gr.Blocks(theme=theme) as demo:
                 preview = gr.Image(label="Preview", visible=False)
 
         with gr.TabItem("Model Manager"):
-            gr.Markdown("WIP")
+            with gr.Tabs():
+                with gr.TabItem("Models"):
+                    gr.FileExplorer(
+                        root_dir=MODELS_DIR,
+                        glob="**/*",
+                        file_count="multiple",
+                        label="Model Files",
+                    )
+                with gr.TabItem("LoRAs"):
+                    gr.FileExplorer(
+                        root_dir=LORA_DIR,
+                        glob="**/*.safetensors",
+                        file_count="multiple",
+                        label="LoRA Files",
+                    )
 
         with gr.TabItem("Gallery"):
             with gr.Row():


### PR DESCRIPTION
## Summary
- provide subtabs for Model Manager
- update README to document the new tabs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `python app.py --help` (interrupted after server start)

------
https://chatgpt.com/codex/tasks/task_e_684fb567e2188333a2f37884d215796d