### PR TITLE
Centralize gradio launch settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ sorted by category. Any additional `.safetensors` or `.ckpt` files placed in
    ```
 
 The interface will be available at `http://localhost:7860/` by default. Use the controls to generate images and browse them in the gallery.
+All Gradio server options (like `share` or custom ports) can be configured in `sdunity/config.py` under `GRADIO_LAUNCH_CONFIG`.
 
 Presets for prompt enhancements are stored in `presets.txt` and can be selected from the dropdown in the UI.
 

--- a/app.py
+++ b/app.py
@@ -139,4 +139,5 @@ with gr.Blocks(theme=theme) as demo:
     )
 
 if __name__ == "__main__":
-    demo.launch(server_name="0.0.0.0", share=False)
+    # Launch Gradio using settings from config for easier customization
+    demo.launch(**config.GRADIO_LAUNCH_CONFIG)

--- a/sdunity/config.py
+++ b/sdunity/config.py
@@ -8,3 +8,32 @@ GENERATIONS_DIR = "generations"
 
 # Ensure generations directory exists
 os.makedirs(GENERATIONS_DIR, exist_ok=True)
+
+# ---------------------------------------------------------------------------
+# Gradio Launch Configuration
+# ---------------------------------------------------------------------------
+# Central location for default `Blocks.launch` arguments. Adjust values here to
+# change how the Gradio server starts. See the Gradio docs for explanation of
+# each option.
+GRADIO_LAUNCH_CONFIG = {
+    # Networking
+    "server_name": "0.0.0.0",  # listen on all interfaces
+    "server_port": None,       # default port (7860)
+    "share": False,            # set True to create a public link
+
+    # Interface behaviour
+    "inbrowser": False,        # open browser automatically on launch
+    "show_error": False,       # display errors in the UI
+    "debug": False,            # enable debug logs
+    "max_threads": 40,         # maximum thread workers
+
+    # Security and authentication
+    "auth": None,              # tuple of (user, pass) or callable
+    "auth_message": None,      # message shown on auth prompt
+    "ssl_keyfile": None,       # path to SSL key
+    "ssl_certfile": None,      # path to SSL certificate
+
+    # Miscellaneous
+    "quiet": False,            # reduce terminal output
+    "show_api": True,          # expose REST API docs
+}


### PR DESCRIPTION
## Summary
- centralize `Blocks.launch` options inside `GRADIO_LAUNCH_CONFIG`
- use the new config dictionary when launching the UI
- mention the new configuration location in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684fbcef34788333aa92cea34e7c5694