### PR TITLE
Implement step streaming preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Text-to-Image generation using Stable Diffusion.
 Prompt + Negative Prompt input fields.
 Real-time seed control.
 Aspect ratio and steps/sampling settings.
-A “Smooth Preview” mode that shows image transitions between steps (like a mini-timelapse).
+A "Smooth Step Streaming" mode that displays each step in real time.
 
 __Optional: Image2Image and Inpainting/Outpainting support (future phase).__
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The UI is organized into tabs for **Generation**, a **Model Manager** with subta
 - Prompt and Negative Prompt inputs
 - Real-time seed control
 - Aspect ratio and sampling step sliders
- - Optional Smooth Preview mode showing intermediate steps as a GIF
+ - Optional Smooth Step Streaming mode displaying intermediate steps in real time
 
 ### Model Selector
 - Choose between predefined Hugging Face models or any files placed in `models/`

--- a/app.py
+++ b/app.py
@@ -140,4 +140,5 @@ with gr.Blocks(theme=theme) as demo:
 
 if __name__ == "__main__":
     # Launch Gradio using settings from config for easier customization
+    demo.queue()
     demo.launch(**config.GRADIO_LAUNCH_CONFIG)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ uvicorn
 diffusers
 torch
 transformers
-imageio
 requests


### PR DESCRIPTION
## Summary
- replace GIF-based Smooth Preview with step streaming using thread queue
- update docs to describe Smooth Step Streaming
- remove imageio dependency
- enable Gradio queue for streaming

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile app.py sdunity/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684fc179c3f083339768b3ef397fc14d