### PR TITLE
Increase preview size & keep preview visible

### DIFF
--- a/app.py
+++ b/app.py
@@ -62,7 +62,7 @@ with gr.Blocks(theme=theme) as demo:
 
             with gr.Row():
                 output = gr.Image(label="Result")
-                preview = gr.Image(label="Preview", visible=False, width=512, height=512)
+                preview = gr.Image(label="Preview", visible=True, width=768, height=768)
 
         with gr.TabItem("Model Manager"):
             with gr.Tabs():

--- a/sdunity/generator.py
+++ b/sdunity/generator.py
@@ -130,4 +130,4 @@ def generate_image(
 
     last_img = images[-1] if images else None
 
-    yield last_img, seed, gr.update(visible=False)
+    yield last_img, seed, gr.update(visible=True)


### PR DESCRIPTION
## Summary
- enlarge preview image display
- keep preview visible after generation finishes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fc5c6a63083339db99752952469d9