### PR TITLE
Fix preview image scaling

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,7 +20,15 @@ theme = gr.themes.Monochrome(primary_hue="slate").set(
     input_background_fill_dark="#222222",
 )
 
-with gr.Blocks(theme=theme) as demo:
+css = """
+#preview img {
+    width: 100% !important;
+    height: 100% !important;
+    object-fit: contain;
+}
+"""
+
+with gr.Blocks(theme=theme, css=css) as demo:
     gr.Markdown("# SDUnity")
 
     with gr.Tabs():
@@ -62,7 +70,13 @@ with gr.Blocks(theme=theme) as demo:
 
             with gr.Row():
                 output = gr.Image(label="Result")
-                preview = gr.Image(label="Preview", visible=True, width=768, height=768)
+                preview = gr.Image(
+                    label="Preview",
+                    visible=True,
+                    width=768,
+                    height=768,
+                    elem_id="preview",
+                )
 
         with gr.TabItem("Model Manager"):
             with gr.Tabs():


### PR DESCRIPTION
## Summary
- keep preview dimensions but ensure preview image fills the container
- add CSS style to scale preview image to the box

## Testing
- `python -m py_compile app.py sdunity/generator.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684fc71950648333a3c4b3f761873a6e