### PR TITLE
Enable per-model backend selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The UI is organized into tabs for **Generation**, a **Model Manager** with subta
 ### Model Selector
 - Choose between predefined Hugging Face models or any files placed in `models/`
 - Supports Stable Diffusion 1.5, SDXL and PonyXL
+- Each model type is powered by its own backend for optimal loading
 
 ### LoRA Library
 - Automatically lists LoRAs found in the `loras/` directory

--- a/app.py
+++ b/app.py
@@ -143,6 +143,7 @@ with gr.Blocks(theme=theme, css=css) as demo:
             steps,
             width,
             height,
+            model_category,
             model,
             lora,
             nsfw_filter,

--- a/sdunity/generator.py
+++ b/sdunity/generator.py
@@ -19,6 +19,7 @@ def generate_image(
     steps: int,
     width: int,
     height: int,
+    model_type: str,
     model: str,
     lora,
     nsfw_filter: bool,
@@ -47,7 +48,7 @@ def generate_image(
         if enhancement:
             prompt = f"{prompt}, {enhancement}"
 
-    pipe = models.get_pipeline(model, progress=progress)
+    pipe = models.get_pipeline(model, progress=progress, category=model_type)
 
     if not hasattr(pipe, "_original_safety_checker"):
         pipe._original_safety_checker = getattr(pipe, "safety_checker", None)
@@ -119,6 +120,7 @@ def generate_image(
                     "steps": int(steps),
                     "width": int(width),
                     "height": int(height),
+                    "model_type": model_type,
                     "model": model,
                     "lora": lora,
                 }


### PR DESCRIPTION
## Summary
- introduce backend classes for SD 1.5 and XL models
- route generator through selected backend using model type
- expose the model type in image metadata
- document backend usage

## Testing
- `python -m py_compile sdunity/models.py sdunity/generator.py app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fcba239708333ac6b327972d3206b