### PR TITLE
Add persistent settings tab

### DIFF
--- a/sdunity/config.py
+++ b/sdunity/config.py
@@ -1,4 +1,5 @@
 import os
+import json
 
 # Directory paths
 MODELS_DIR = "models"
@@ -37,3 +38,45 @@ GRADIO_LAUNCH_CONFIG = {
     "quiet": False,            # reduce terminal output
     "show_api": True,          # expose REST API docs
 }
+
+# ---------------------------------------------------------------------------
+# User Configuration
+# ---------------------------------------------------------------------------
+# Settings in this section are persisted to ``config/user_config.json`` so that
+# changes made in the UI survive restarts.
+
+USER_CONFIG_PATH = os.path.join("config", "user_config.json")
+
+# Default values for the user configuration. We include all Gradio launch
+# options so they can be customized from the UI along with the Civitai API key.
+DEFAULT_USER_CONFIG = {"civitai_api_key": "", **GRADIO_LAUNCH_CONFIG}
+
+
+def load_user_config() -> dict:
+    """Load the persistent user configuration from disk."""
+    if os.path.isfile(USER_CONFIG_PATH):
+        with open(USER_CONFIG_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    else:
+        data = {}
+    cfg = DEFAULT_USER_CONFIG.copy()
+    cfg.update(data)
+    return cfg
+
+
+USER_CONFIG = load_user_config()
+
+
+def save_user_config(cfg: dict | None = None) -> None:
+    """Persist the provided user configuration to disk."""
+    if cfg is None:
+        cfg = USER_CONFIG
+    os.makedirs(os.path.dirname(USER_CONFIG_PATH), exist_ok=True)
+    with open(USER_CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)
+
+
+# Update the launch config based on the loaded user settings
+for key in GRADIO_LAUNCH_CONFIG:
+    if key in USER_CONFIG:
+        GRADIO_LAUNCH_CONFIG[key] = USER_CONFIG[key]


### PR DESCRIPTION
## Summary
- allow saving/loading settings from `config/user_config.json`
- support Civitai API key in civitai module
- new Settings tab for editing launch options and API key

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684fd840b32883339c58f68aacc5e8fc