### PR TITLE
Add CLI downloader for Civitai models

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ All predefined models are listed in `config/model_registry.json`. Run
 sorted by category. Any additional `.safetensors` or `.ckpt` files placed in
 `models/` are automatically detected by the app.
 
+### Downloading from Civitai on the command line
+
+If you want to fetch a model from Civitai without using the web interface,
+use the helper script below. It prints the download progress to the console.
+
+```bash
+python scripts/civitai_download.py <download_url> [destination] --api-key YOUR_KEY
+```
+
 ## Setup
 
 1. Install dependencies:

--- a/scripts/civitai_download.py
+++ b/scripts/civitai_download.py
@@ -1,0 +1,31 @@
+import argparse
+import os
+from sdunity import civitai, config
+
+
+def cli_progress(x: int, desc: str = "", total: int = 0) -> None:
+    """Simple console progress printer."""
+    if total:
+        pct = x / total * 100
+        print(f"\r{desc} {pct:.1f}% ({x}/{total})", end="", flush=True)
+    else:
+        print(f"\r{desc} {x} bytes", end="", flush=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download a Civitai model")
+    parser.add_argument("url", help="Civitai download URL")
+    parser.add_argument("dest", nargs="?", default=config.MODELS_DIR, help="Destination directory")
+    parser.add_argument("--api-key", dest="api_key", help="Civitai API key", default=None)
+    args = parser.parse_args()
+
+    if args.api_key:
+        civitai.set_api_key(args.api_key)
+
+    os.makedirs(args.dest, exist_ok=True)
+    path = civitai.download_model(args.url, args.dest, progress=cli_progress)
+    print(f"\nSaved to {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `civitai_download.py` helper to download models with console progress
- document command-line Civitai downloads in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684fdf213c80833386bbc2166ec3bf8d