### PR TITLE
Fix unresponsive popup

### DIFF
--- a/app.py
+++ b/app.py
@@ -327,7 +327,11 @@ with gr.Blocks(theme=theme, css=css) as demo:
         inputs=[civitai_results, civitai_type, civitai_state],
         outputs=popup_status,
     )
-    popup_close.click(_close_download_popup, outputs=download_popup)
+    popup_close.click(
+        _close_download_popup,
+        outputs=download_popup,
+        _js="() => { const el = document.getElementById('download_popup'); if (el) el.style.display = 'none'; }",
+    )
 
 if __name__ == "__main__":
     # Launch Gradio using settings from config for easier customization


### PR DESCRIPTION
## Summary
- make download popup closable without backend

## Testing
- `python -m py_compile app.py`
- `python -m py_compile sdunity/*.py scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684ff9eacff88333af7718bb2ef7ab97