### PR TITLE
Fix popup close button js parameter

### DIFF
--- a/app.py
+++ b/app.py
@@ -330,7 +330,7 @@ with gr.Blocks(theme=theme, css=css) as demo:
     popup_close.click(
         _close_download_popup,
         outputs=download_popup,
-        _js="() => { const el = document.getElementById('download_popup'); if (el) el.style.display = 'none'; }",
+        js="() => { const el = document.getElementById('download_popup'); if (el) el.style.display = 'none'; }",
     )
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix `popup_close.click()` to use `js` parameter

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6850020593ec8333b67f3fcffce1610b