### PR TITLE
Add Bootcamp training tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 **SDUnity** is a self‑hosted web interface built with [Gradio](https://www.gradio.app/) for working with Stable Diffusion models. The application brings model management, LoRA handling and an image gallery together under a single UI.
 
-The interface uses a modern dark theme and is divided into four main tabs:
+The interface uses a modern dark theme and is divided into five main tabs:
 
 - **Generation** – create images from text prompts
 - **Model Manager** – browse models and LoRAs or search Civitai
 - **Gallery** – view previous generations
+- **Bootcamp** – LoRA training (work in progress)
 - **Settings** – configure persistent options
 
 ## Features
@@ -29,6 +30,9 @@ The interface uses a modern dark theme and is divided into four main tabs:
 ### Web Gallery
 - Browse all saved images from `generations/`
 - Display metadata such as prompt, model, LoRA and seed
+
+### Bootcamp (WIP)
+- Simple interface to launch LoRA training using the diffusers DreamBooth script
 
 ## Built‑in Models
 

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import sys
 import gradio as gr
 from PIL import Image
 
-from sdunity import presets, models, generator, gallery, config, civitai
+from sdunity import presets, models, generator, gallery, config, civitai, bootcamp
 
 MODEL_DIR_MAP = {"sd15": "SD15", "sdxl": "SDXL", "ponyxl": "PonyXL"}
 
@@ -221,6 +221,17 @@ with gr.Blocks(theme=theme, css=css) as demo:
                         return gr.update(value=f"Saved to {os.path.basename(path)}")
                 return gr.update(value="Model not found")
 
+        with gr.TabItem("Bootcamp"):
+            with gr.Row():
+                with gr.Column(scale=1):
+                    bc_instance = gr.Textbox(label="Instance Images", value="data/instance")
+                    bc_model = gr.Textbox(label="Base Model", value="")
+                    bc_output = gr.Textbox(label="Output Directory", value="loras/bootcamp")
+                    bc_steps = gr.Number(label="Steps", value=1000, precision=0)
+                    bc_lr = gr.Number(label="Learning Rate", value=1e-4)
+                    bc_start = gr.Button("Start Bootcamp", variant="primary")
+                bc_log = gr.Markdown()
+
         with gr.TabItem("Settings"):
             settings_inputs = []
             civitai_key = gr.Textbox(
@@ -306,6 +317,12 @@ with gr.Blocks(theme=theme, css=css) as demo:
         ),
         inputs=model_category,
         outputs=model,
+    )
+
+    bc_start.click(
+        bootcamp.train_lora,
+        inputs=[bc_instance, bc_model, bc_output, bc_steps, bc_lr],
+        outputs=bc_log,
     )
 
     civitai_search.click(

--- a/sdunity/__init__.py
+++ b/sdunity/__init__.py
@@ -1,4 +1,4 @@
-from . import presets, models, gallery, generator, config, civitai
+from . import presets, models, gallery, generator, config, civitai, bootcamp
 
 __all__ = [
     "presets",
@@ -7,4 +7,5 @@ __all__ = [
     "generator",
     "config",
     "civitai",
+    "bootcamp",
 ]

--- a/sdunity/bootcamp.py
+++ b/sdunity/bootcamp.py
@@ -1,0 +1,56 @@
+"""Bootcamp - LoRA training utilities (WIP)."""
+
+import shutil
+import subprocess
+from typing import Generator
+
+import gradio as gr
+
+
+BOOTCAMP_SCRIPT = "train_dreambooth_lora.py"
+
+
+def train_lora(
+    instance_dir: str,
+    pretrained_model: str,
+    output_dir: str,
+    steps: int = 1000,
+    learning_rate: float = 1e-4,
+    progress: gr.Progress | None = None,
+) -> Generator[str, None, None]:
+    """Launch LoRA training via the diffusers DreamBooth script.
+
+    This is a minimal wrapper around the official training script and is
+    provided as a work in progress. It requires ``accelerate`` and
+    ``diffusers[training]`` to be installed and accessible on the system.
+    """
+    if progress:
+        progress(0, desc="Bootcamp initialising")
+
+    if not shutil.which("accelerate"):
+        yield "`accelerate` command not found. Please install diffusers training requirements."
+        return
+
+    cmd = [
+        "accelerate",
+        "launch",
+        BOOTCAMP_SCRIPT,
+        "--pretrained_model_name_or_path",
+        pretrained_model,
+        "--instance_data_dir",
+        instance_dir,
+        "--output_dir",
+        output_dir,
+        "--max_train_steps",
+        str(int(steps)),
+        "--learning_rate",
+        str(learning_rate),
+    ]
+    yield f"Starting Bootcamp with {steps} steps..."
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as exc:
+        yield f"Training failed: {exc}"
+        return
+
+    yield f"Training complete. LoRA saved to {output_dir}"


### PR DESCRIPTION
## Summary
- introduce `bootcamp.py` with a helper to run the diffusers LoRA training script
- hook Bootcamp tab into the UI and connect to the new training helper
- expose Bootcamp in the package
- document Bootcamp in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850053ff14883338bce6ff065db702b