### PR TITLE
Use venv in maintainer and add start helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ python scripts/civitai_download.py <download_url> [destination] --api-key YOUR_K
 
 ## Setup
 
-1. Install dependencies:
+1. Create a virtual environment and install dependencies:
    ```bash
+   python3 -m venv venv
+   source venv/bin/activate
    pip install -r requirements.txt
    ```
 2. (Optional) analyse an image folder:
@@ -67,9 +69,9 @@ python scripts/civitai_download.py <download_url> [destination] --api-key YOUR_K
    mkdir -p models loras
    python scripts/download_models.py
    ```
-4. Launch the app:
+4. Launch the app using the helper script:
    ```bash
-   python app.py
+   ./start.sh
    ```
 
 The interface runs on `http://localhost:7860/` by default. Gradio launch options can be adjusted from the Settings tab or by editing `sdunity/config.py` under `GRADIO_LAUNCH_CONFIG`.
@@ -79,7 +81,8 @@ Prompt presets live in `presets.txt` and can be selected from the dropdown in th
 ## Maintainer Script
 
 For a fully automated setup you can use `maintainer.sh` which supports
-`install`, `update` and `uninstall` commands. Run the script with `sudo`:
+`install`, `update` and `uninstall` commands. The script manages its own
+virtual environment under `/opt/SDUnity/venv`. Run it with `sudo`:
 
 ```bash
 sudo ./maintainer.sh install    # install SDUnity under /opt/SDUnity
@@ -87,4 +90,4 @@ sudo ./maintainer.sh update     # pull latest changes and upgrade deps
 sudo ./maintainer.sh uninstall  # remove the installed files
 ```
 
-The script depends on `git`, `python3` and `pip3` being available.
+The script depends on `git` and `python3` being available.

--- a/maintainer.sh
+++ b/maintainer.sh
@@ -11,6 +11,7 @@ if [ "$EUID" -ne 0 ]; then
 fi
 
 TARGET_DIR="/opt/SDUnity"
+VENV_DIR="$TARGET_DIR/venv"
 
 # Repository to clone from when installing
 REPO_URL="https://github.com/AsaTyr2018/SDUnity.git"
@@ -26,12 +27,18 @@ if [ -n "$REPO_SRC" ]; then
 fi
 
 check_deps() {
-    for cmd in git python3 pip3; do
-        if ! command -v $cmd >/dev/null 2>&1; then
+    for cmd in git python3; do
+        if ! command -v "$cmd" >/dev/null 2>&1; then
             echo "Error: $cmd is required but not installed." >&2
             exit 1
         fi
     done
+}
+
+ensure_venv() {
+    if [ ! -d "$VENV_DIR" ]; then
+        python3 -m venv "$VENV_DIR"
+    fi
 }
 
 fix_permissions() {
@@ -42,13 +49,14 @@ fix_permissions() {
 
 install_sdunity() {
     check_deps
+    ensure_venv
     if [ -d "$TARGET_DIR/.git" ]; then
         echo "SDUnity already installed in $TARGET_DIR"
     else
         echo "Cloning SDUnity into $TARGET_DIR"
         git clone "$REPO_URL" "$TARGET_DIR"
     fi
-    pip3 install -r "$TARGET_DIR/requirements.txt"
+    "$VENV_DIR/bin/pip" install -r "$TARGET_DIR/requirements.txt"
     fix_permissions
     echo "Installation completed."
 }
@@ -61,7 +69,8 @@ update_sdunity() {
     fi
     cd "$TARGET_DIR"
     git pull
-    pip3 install -r requirements.txt
+    ensure_venv
+    "$VENV_DIR/bin/pip" install -r requirements.txt
     fix_permissions
     echo "Update completed."
 }

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="$SCRIPT_DIR/venv"
+if [ ! -d "$VENV_DIR" ]; then
+    echo "Creating virtual environment at $VENV_DIR"
+    python3 -m venv "$VENV_DIR"
+fi
+source "$VENV_DIR/bin/activate"
+exec python "$SCRIPT_DIR/app.py" "$@"


### PR DESCRIPTION
## Summary
- use a dedicated virtual environment in maintainer script
- add `start.sh` to activate the venv and run the app
- document new workflow in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685026924ef88333acb24c364a601a8a