### PR TITLE
Fix install path error in maintainer script

### DIFF
--- a/maintainer.sh
+++ b/maintainer.sh
@@ -49,13 +49,13 @@ fix_permissions() {
 
 install_sdunity() {
     check_deps
-    ensure_venv
     if [ -d "$TARGET_DIR/.git" ]; then
         echo "SDUnity already installed in $TARGET_DIR"
     else
         echo "Cloning SDUnity into $TARGET_DIR"
         git clone "$REPO_URL" "$TARGET_DIR"
     fi
+    ensure_venv
     "$VENV_DIR/bin/pip" install -r "$TARGET_DIR/requirements.txt"
     fix_permissions
     echo "Installation completed."


### PR DESCRIPTION
## Summary
- avoid creating the virtual environment before cloning

## Testing
- `bash -n maintainer.sh`
- `python3 -m py_compile app.py sdunity/*.py scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68502b5ca8e08333a686aa528b778875