### PR TITLE
Adjust generator UI layout

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,23 +67,6 @@ with gr.Blocks(theme=theme, css=css) as demo:
                     generate_btn = gr.Button("Generate", variant="primary")
 
                 with gr.Column(scale=1):
-                    with gr.Accordion("Model", open=True):
-                        categories = models.list_categories()
-                        model_category = gr.Radio(
-                            choices=categories,
-                            value=categories[0] if categories else None,
-                            label="Model Type",
-                        )
-                        model = gr.Dropdown(
-                            choices=models.list_models(
-                                categories[0] if categories else None
-                            ),
-                            label="Model",
-                        )
-                        lora = gr.Dropdown(
-                            choices=models.list_loras(), label="LoRA", multiselect=True
-                        )
-                        refresh = gr.Button("Refresh")
                     with gr.Accordion("Generation Settings", open=False):
                         seed = gr.Number(label="Seed", value=None, precision=0)
                         random_seed_chk = gr.Checkbox(label="Random Seed", value=False)
@@ -102,9 +85,28 @@ with gr.Blocks(theme=theme, css=css) as demo:
                         )
 
             with gr.Row():
-                output = gr.Image(label="Result")
-                preview = gr.Image(
-                    label="Preview",
+                with gr.Column():
+                    with gr.Accordion("Model", open=True):
+                        categories = models.list_categories()
+                        model_category = gr.Radio(
+                            choices=categories,
+                            value=categories[0] if categories else None,
+                            label="Model Type",
+                        )
+                        model = gr.Dropdown(
+                            choices=models.list_models(
+                                categories[0] if categories else None
+                            ),
+                            label="Model",
+                        )
+                        lora = gr.Dropdown(
+                            choices=models.list_loras(), label="LoRA", multiselect=True
+                        )
+                        refresh = gr.Button("Refresh")
+
+            with gr.Row():
+                output = gr.Image(
+                    label="Result",
                     visible=True,
                     width=768,
                     height=768,
@@ -319,7 +321,7 @@ with gr.Blocks(theme=theme, css=css) as demo:
             preset,
             smooth_preview_chk,
         ],
-        outputs=[output, seed, preview],
+        outputs=[output, seed],
     )
     refresh.click(
         models.refresh_lists,

--- a/sdunity/generator.py
+++ b/sdunity/generator.py
@@ -2,7 +2,6 @@ import random
 import inspect
 import threading
 from queue import Queue
-from typing import Tuple
 from PIL import Image
 import numpy as np
 import torch
@@ -28,7 +27,7 @@ def generate_image(
     preset: str,
     smooth_preview: bool,
     progress=gr.Progress(),
-) -> Tuple[Image.Image, int, bytes]:
+) -> tuple[Image.Image | None, int]:
     """Generate one or more images using the selected diffusion model.
 
     Parameters
@@ -137,11 +136,11 @@ def generate_image(
             frame = preview_queue.get()
             if frame is _STOP:
                 break
-            yield None, seed, gr.update(value=frame, visible=True)
+            yield frame, seed
         thread.join()
     else:
         _run_generation()
 
     last_img = images[-1] if images else None
 
-    yield last_img, seed, gr.update(visible=True)
+    yield last_img, seed


### PR DESCRIPTION
## Summary
- reorganize Generation tab layout
- combine preview and result into one output image
- simplify generator outputs

## Testing
- `python3 -m py_compile app.py sdunity/*.py`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68503d44175c8333b226bb617583e7d1