### PR TITLE
Enhance Civitai browser with metadata and version selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The interface uses a modern dark theme and is divided into five main tabs:
 ### Model Management
 - Choose between predefined models or any files in `models/`
 - LoRA dropdown lists files from `loras/` with multi‑select support
-- Built‑in Civitai browser to search and download checkpoints
+- Built‑in Civitai browser to search, inspect metadata and download model versions
 - Move or delete model files from within the manager
 
 ### Web Gallery


### PR DESCRIPTION
## Summary
- extend Civitai API helper to return detailed metadata and all versions
- add `format_metadata` helper for simple display
- update Model Manager UI: show model metadata and version selector
- display metadata and update preview when selecting models/versions
- adjust download logic to use selected version
- mention the new capabilities in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685041fe797c833382847b905fab50b5