### PR TITLE
Fix civitai progress bar

### DIFF
--- a/app.py
+++ b/app.py
@@ -283,7 +283,7 @@ with gr.Blocks(theme=theme, css=css) as demo:
                                 dest = os.path.join(dest_dir, filename)
                                 total = int(resp.headers.get("content-length", 0))
                                 downloaded = 0
-                                progress(0, desc=f"Downloading {filename}", total=total)
+                                progress((0, total), desc=f"Downloading {filename}")
                                 yield gr.update(value="Download running... 0%"), gr.update(value="0%")
                                 last_percent = 0
                                 with open(dest, "wb") as f:
@@ -294,17 +294,13 @@ with gr.Blocks(theme=theme, css=css) as demo:
                                         downloaded += len(chunk)
                                         if total:
                                             percent = int(downloaded / total * 100)
-                                            progress(
-                                                downloaded,
-                                                desc=f"Downloading {filename}",
-                                                total=total,
-                                            )
+                                            progress((downloaded, total), desc=f"Downloading {filename}")
                                             if percent - last_percent >= 5:
                                                 last_percent = percent
                                                 yield gr.update(
                                                     value=f"Download running... {percent}%"
                                                 ), gr.update(value=f"{percent}%")
-                                progress(total, desc="Download complete", total=total)
+                                progress((total, total), desc="Download complete")
                                 yield gr.update(value=f"Saved to {os.path.basename(dest)}"), gr.update(value="Done")
                                 return
                 yield gr.update(value="Model not found"), gr.update(value="")

--- a/sdunity/civitai.py
+++ b/sdunity/civitai.py
@@ -112,7 +112,7 @@ def download_model(download_url: str, dest_dir: str, progress=None) -> str:
     total = int(resp.headers.get("content-length", 0))
     downloaded = 0
     if progress is not None:
-        progress(0, desc=f"Downloading {filename}", total=total)
+        progress((0, total), desc=f"Downloading {filename}")
     with open(dest, "wb") as f:
         for chunk in resp.iter_content(chunk_size=8192):
             if not chunk:
@@ -120,9 +120,9 @@ def download_model(download_url: str, dest_dir: str, progress=None) -> str:
             f.write(chunk)
             downloaded += len(chunk)
             if progress is not None and total:
-                progress(downloaded, desc=f"Downloading {filename}", total=total)
+                progress((downloaded, total), desc=f"Downloading {filename}")
     if progress is not None:
-        progress(total, desc="Download complete", total=total)
+        progress((total, total), desc="Download complete")
     return dest
 
 

--- a/sdunity/models.py
+++ b/sdunity/models.py
@@ -123,7 +123,7 @@ def download_model_file(model_name: str, progress=None) -> str:
         total = int(resp.headers.get("content-length", 0))
         downloaded = 0
         if progress:
-            progress(0, desc=f"Downloading {model_name}", total=total)
+            progress((0, total), desc=f"Downloading {model_name}")
         with open(dest, "wb") as f:
             for chunk in resp.iter_content(chunk_size=8192):
                 if not chunk:
@@ -131,9 +131,9 @@ def download_model_file(model_name: str, progress=None) -> str:
                 f.write(chunk)
                 downloaded += len(chunk)
                 if progress and total:
-                    progress(downloaded, desc=f"Downloading {model_name}", total=total)
+                    progress((downloaded, total), desc=f"Downloading {model_name}")
         if progress:
-            progress(total, desc="Download complete", total=total)
+            progress((total, total), desc="Download complete")
     except Exception as e:
         if os.path.exists(dest):
             os.remove(dest)


### PR DESCRIPTION
## Summary
- use tuple updates for `gr.Progress` when downloading models
- update Civitai download progress handlers in app and utility modules

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685043eaf4c48333956d2535d2ef0425