### PR TITLE
Adjust Civitai search defaults

### DIFF
--- a/sdunity/civitai.py
+++ b/sdunity/civitai.py
@@ -32,9 +32,13 @@ def search_models(
     query: str = "",
     model_type: str = "sd15",
     sort: str = "Most Downloaded",
-    limit: int = 20,
+    limit: int = 70,
 ):
-    """Search models on Civitai and return metadata and versions."""
+    """Search models on Civitai and return metadata and versions.
+
+    If ``query`` is provided, the API's ``query`` parameter is used to
+    filter results by name.
+    """
 
     params = {
         "types": "Checkpoint",


### PR DESCRIPTION
## Summary
- raise default result limit for Civitai model search
- clarify search behavior when a query is provided

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68504da1e9e883338244893ee13fe426