### PR TITLE
Add direct link download support in Civitai browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The interface uses a modern dark theme and is divided into five main tabs:
 - Choose from any files in `models/`
 - LoRA dropdown lists files from `loras/` with multi‑select support
 - Built‑in Civitai browser to search, inspect metadata and download model versions
+- Paste a Civitai link to download directly
 - Move or delete model files from within the manager
 
 ### Web Gallery


### PR DESCRIPTION
## Summary
- enable downloading models using a direct Civitai link
- add link input and button in the Civitai browser UI
- document the new ability in README

## Testing
- `python -m py_compile app.py sdunity/*.py scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6850524e9f8c8333b616b561a9639ca5