### PR TITLE
Add gallery for current batch

### DIFF
--- a/app.py
+++ b/app.py
@@ -81,6 +81,8 @@ with gr.Blocks(theme=theme, css=css) as demo:
                     height=768,
                     elem_id="preview",
                 )
+            with gr.Row():
+                gen_gallery = gr.Gallery(label="Current Batch", show_label=True)
 
         with gr.TabItem("Generation Settings"):
             seed = gr.Number(label="Seed", value=None, precision=0)
@@ -417,7 +419,7 @@ with gr.Blocks(theme=theme, css=css) as demo:
             preset,
             smooth_preview_chk,
         ],
-        outputs=[output, seed],
+        outputs=[output, seed, gen_gallery],
     )
     refresh.click(
         models.refresh_lists,


### PR DESCRIPTION
## Summary
- collect generated image paths in generator
- show a gallery of the current batch in the Generation tab

## Testing
- `python -m py_compile app.py sdunity/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685066e937388333b67890ff4496073e