### PR TITLE
Make gallery thumbnails smaller

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,6 +47,15 @@ css = """
     width: 254px !important;
     height: 254px !important;
 }
+#imagesgallery .gallery-item {
+    width: 128px !important;
+    height: 128px !important;
+}
+#imagesgallery img {
+    object-fit: contain;
+    width: 128px !important;
+    height: 128px !important;
+}
 """
 
 with gr.Blocks(theme=theme, css=css) as demo:
@@ -240,7 +249,11 @@ with gr.Blocks(theme=theme, css=css) as demo:
         with gr.TabItem("Gallery"):
             with gr.Row():
                 with gr.Column(scale=2):
-                    gallery_grid = gr.Gallery(label="Images", show_label=True)
+                    gallery_grid = gr.Gallery(
+                        label="Images",
+                        show_label=True,
+                        elem_id="imagesgallery",
+                    )
                     refresh_gallery = gr.Button("Refresh")
                 with gr.Column(scale=1):
                     selected_image = gr.Image(label="Image")


### PR DESCRIPTION
## Summary
- style the images gallery for smaller thumbnails
- mark the gallery with an element ID for CSS styling

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68507c4e786883338dc38bc19a13a6e4