### PR TITLE
Fix LoRA adapter names

### DIFF
--- a/sdunity/generator.py
+++ b/sdunity/generator.py
@@ -137,8 +137,9 @@ def generate_image(
             path = models.LORA_LOOKUP.get(name)
             if path and hasattr(pipe, "load_lora_weights"):
                 try:
-                    pipe.load_lora_weights(path, adapter_name=name)
-                    adapter_names.append(name)
+                    adapter_id = os.path.splitext(name)[0]
+                    pipe.load_lora_weights(path, adapter_name=adapter_id)
+                    adapter_names.append(adapter_id)
                     adapter_weights.append(float(lora_weight))
                 except Exception:
                     pass


### PR DESCRIPTION
## Summary
- ensure LoRA adapter names don't include file extensions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68511881dd4c8333849be4b295c61f2f