### PR TITLE
Add offline GPT2 prompt enhancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The interface uses a modern dark theme and is divided into five main tabs:
 - NSFW filter toggle
 - Multiple images per batch and batch repetition
 - Selectable prompt presets
+- Optional GPT-2 based prompt enhancement
 - Choice of sampler and precision
 - LoRA weight slider and tiling option
 - Denoising strength control
@@ -68,6 +69,9 @@ Start the web interface with:
 The interface runs on `http://localhost:7860/` by default. Gradio launch options can be adjusted from the Settings tab or by editing `sdunity/config.py` under `GRADIO_LAUNCH_CONFIG`.
 
 Prompt presets live in `presets.txt` and can be selected from the dropdown in the Generation tab.
+
+Setting the environment variable `SDUNITY_GPT2_MODEL` allows choosing a different GPT-2
+checkpoint for the auto enhancement feature.
 
 LoRA support relies on the [peft](https://github.com/huggingface/peft) package. If you install
 SDUnity manually, make sure all dependencies from `requirements.txt` are installed with

--- a/app.py
+++ b/app.py
@@ -106,6 +106,9 @@ with gr.Blocks(theme=theme, css=css) as demo:
                         label="Preset",
                         value=None,
                     )
+                    auto_enhance_chk = gr.Checkbox(
+                        label="Auto Enhance Prompt", value=False
+                    )
                     generate_btn = gr.Button("Generate", variant="primary")
 
                 with gr.Column(scale=1):
@@ -741,6 +744,7 @@ with gr.Blocks(theme=theme, css=css) as demo:
             images_per_batch,
             batch_count,
             preset,
+            auto_enhance_chk,
             smooth_preview_chk,
             scheduler,
             precision_dd,

--- a/sdunity/enhancer.py
+++ b/sdunity/enhancer.py
@@ -1,0 +1,33 @@
+import os
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+
+# Default model name can be overridden with SDUNITY_GPT2_MODEL env var
+_DEFAULT_MODEL = os.getenv("SDUNITY_GPT2_MODEL", "gpt2")
+
+_pipeline = None
+_loaded_model = None
+
+def _load(model_name: str | None = None):
+    """Load the GPT-2 model for prompt enhancement."""
+    global _pipeline, _loaded_model
+    name = model_name or _DEFAULT_MODEL
+    if _pipeline is None or _loaded_model != name:
+        tokenizer = AutoTokenizer.from_pretrained(name)
+        model = AutoModelForCausalLM.from_pretrained(name)
+        _pipeline = pipeline("text-generation", model=model, tokenizer=tokenizer)
+        _loaded_model = name
+
+
+def enhance(prompt: str, max_tokens: int = 50) -> str:
+    """Return an enhanced version of the given prompt using GPT-2."""
+    if not prompt:
+        return prompt
+    _load()
+    text = f"Improve this Stable Diffusion prompt: {prompt}\nEnhanced:"
+    result = _pipeline(text, max_new_tokens=max_tokens, do_sample=False)
+    generated = result[0]["generated_text"]
+    if "Enhanced:" in generated:
+        enhanced = generated.split("Enhanced:", 1)[-1].strip()
+    else:
+        enhanced = generated.strip()
+    return enhanced or prompt


### PR DESCRIPTION
## Summary
- add optional GPT-2 prompt enhancement module
- hook auto enhancement into generator
- expose `Auto Enhance Prompt` checkbox in UI
- document feature and environment variable

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68511e1e19748333be06c74ce177c923