### PR TITLE
Enhance GPT-2 prompt enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The interface uses a modern dark theme and is divided into five main tabs:
 - NSFW filter toggle
 - Multiple images per batch and batch repetition
 - Selectable prompt presets
-- Optional GPT-2 based prompt enhancement
+- Optional GPT-2 based prompt enhancement with deduplication
 - Choice of sampler and precision
 - LoRA weight slider and tiling option
 - Denoising strength control
@@ -71,7 +71,8 @@ The interface runs on `http://localhost:7860/` by default. Gradio launch options
 Prompt presets live in `presets.txt` and can be selected from the dropdown in the Generation tab.
 
 Setting the environment variable `SDUNITY_GPT2_MODEL` allows choosing a different GPT-2
-checkpoint for the auto enhancement feature.
+checkpoint for the auto enhancement feature. The generator now removes duplicate
+tags automatically.
 
 LoRA support relies on the [peft](https://github.com/huggingface/peft) package. If you install
 SDUnity manually, make sure all dependencies from `requirements.txt` are installed with

--- a/sdunity/enhancer.py
+++ b/sdunity/enhancer.py
@@ -14,7 +14,15 @@ def _load(model_name: str | None = None):
     if _pipeline is None or _loaded_model != name:
         tokenizer = AutoTokenizer.from_pretrained(name)
         model = AutoModelForCausalLM.from_pretrained(name)
-        _pipeline = pipeline("text-generation", model=model, tokenizer=tokenizer)
+        _pipeline = pipeline(
+            "text-generation",
+            model=model,
+            tokenizer=tokenizer,
+            # Slight sampling to avoid repetitive outputs
+            do_sample=True,
+            temperature=0.9,
+            top_p=0.95,
+        )
         _loaded_model = name
 
 
@@ -28,11 +36,17 @@ def enhance(prompt: str, max_tokens: int = 50) -> str:
         "Only return a comma-separated list of tags in Danbooru style. Do not use full sentences.\n\n"
         f"{prompt}\nTags:"
     )
-    result = _pipeline(text, max_new_tokens=max_tokens, do_sample=False)
+    result = _pipeline(text, max_new_tokens=max_tokens)
     generated = result[0]["generated_text"]
     if "Tags:" in generated:
         enhanced = generated.split("Tags:", 1)[-1].strip()
     else:
         enhanced = generated.strip()
-    tags = [t.strip() for t in enhanced.split(",") if t.strip()]
+    seen = set()
+    tags = []
+    for t in enhanced.split(","):
+        tok = t.strip()
+        if tok and tok not in seen:
+            tags.append(tok)
+            seen.add(tok)
     return ", ".join(tags) if tags else prompt


### PR DESCRIPTION
## Summary
- tune the GPT-2 text generation pipeline to use sampling and avoid repetitive output
- deduplicate generated tags in `enhancer.py`
- document deduplication behavior in README

## Testing
- `python -m py_compile sdunity/enhancer.py`


------
https://chatgpt.com/codex/tasks/task_e_68516d7e497c8333bd2cce1e58efa7cc