### PR TITLE
Revamp tag suggestions integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ The UI is split into tabs for generation, model management, a gallery, a Bootcam
 - Search Civitai with dedicated tags for SD 1.5, SDXL and Pony models
 - Inspect versions and previews before downloading
 
-### Tag Suggestions (WIP)
-- Auto complete prompt tags using a local dataset
+### Tag Suggestions
+- Auto complete prompt tags using a local dataset, directly inside the prompt field
 
 ## Setup
 Clone the repository and run the maintainer script to install SDUnity under `/opt/SDUnity` with its own virtual environment:

--- a/app.py
+++ b/app.py
@@ -86,6 +86,16 @@ css = """
     width: 128px !important;
     height: 128px !important;
 }
+#prompt_wrapper {
+    position: relative;
+}
+#tag_suggestions {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 10;
+}
 """
 with gr.Blocks(theme=theme, css=css) as demo:
     gr.Markdown("# SDUnity")
@@ -94,12 +104,15 @@ with gr.Blocks(theme=theme, css=css) as demo:
         with gr.TabItem("Generation"):
             with gr.Row():
                 with gr.Column(scale=2):
-                    prompt = gr.Textbox(label="Prompt", lines=2)
-                    tag_suggestions = gr.Dropdown(
-                        label="Tag Suggestions",
-                        choices=[],
-                        visible=False,
-                    )
+                    with gr.Box(elem_id="prompt_wrapper"):
+                        prompt = gr.Textbox(label="Prompt", lines=2)
+                        tag_suggestions = gr.Dropdown(
+                            label="",
+                            choices=[],
+                            visible=False,
+                            container=False,
+                            elem_id="tag_suggestions",
+                        )
                     negative_prompt = gr.Textbox(label="Negative Prompt", lines=2)
                     preset = gr.Dropdown(
                         choices=list(presets.PRESETS.keys()),


### PR DESCRIPTION
## Summary
- integrate dropdown with prompt textbox for tag suggestions
- update overlay CSS
- document the new behaviour in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68517ba38ea483339cbbe8fd042f5bcc