### PR TITLE
Fix gradio container attribute error

### DIFF
--- a/app.py
+++ b/app.py
@@ -104,7 +104,7 @@ with gr.Blocks(theme=theme, css=css) as demo:
         with gr.TabItem("Generation"):
             with gr.Row():
                 with gr.Column(scale=2):
-                    with gr.Box(elem_id="prompt_wrapper"):
+                    with gr.Group(elem_id="prompt_wrapper"):
                         prompt = gr.Textbox(label="Prompt", lines=2)
                         tag_suggestions = gr.Dropdown(
                             label="",


### PR DESCRIPTION
## Summary
- replace deprecated `gr.Box` with `gr.Group`

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_68517f36272483339abe30962ebfd9c6