### PR TITLE
Integrate tagcomplete tag lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ The UI is split into tabs for generation, model management, a gallery, a Bootcam
 - Inspect versions and previews before downloading
 
 ### Tag Suggestions
-- Auto complete prompt tags using a local dataset, directly inside the prompt field
+- Auto complete prompt tags using a local dataset, directly inside the prompt field.
+- Run `scripts/import_tagcomplete.py` with a clone of
+  [a1111-sd-webui-tagcomplete](https://github.com/DominikDoom/a1111-sd-webui-tagcomplete)
+  to refresh the tag list from its CSV files.
 
 ## Setup
 Clone the repository and run the maintainer script to install SDUnity under `/opt/SDUnity` with its own virtual environment:

--- a/scripts/import_tagcomplete.py
+++ b/scripts/import_tagcomplete.py
@@ -1,0 +1,32 @@
+import argparse
+import importlib.util
+import os
+from pathlib import Path
+
+_TAG_PATH = Path(__file__).resolve().parent.parent / "sdunity" / "tags.py"
+spec = importlib.util.spec_from_file_location("sdunity_tags", _TAG_PATH)
+tags = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(tags)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Merge tags from a1111-sd-webui-tagcomplete into the local dataset"
+    )
+    parser.add_argument(
+        "repo",
+        help="Path to the cloned a1111-sd-webui-tagcomplete repository"
+    )
+    parser.add_argument(
+        "--output",
+        default="data/all_tags.csv",
+        help="Destination CSV file"
+    )
+    args = parser.parse_args()
+
+    tags.update_dataset_from_tagcomplete(args.repo, args.output)
+    print(f"Updated tag dataset written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add helper script to merge tags from `a1111-sd-webui-tagcomplete`
- support importing tagcomplete CSV files in `sdunity.tags`
- document new script in README

## Testing
- `python -m py_compile sdunity/tags.py scripts/import_tagcomplete.py`


------
https://chatgpt.com/codex/tasks/task_e_685190d9d6a08333b9e8ccbd87b05388