### PR TITLE
Automate tagcomplete dataset refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ The UI is split into tabs for generation, model management, a gallery, a Bootcam
 
 ### Tag Suggestions
 - Auto complete prompt tags using a local dataset, directly inside the prompt field.
-- Run `scripts/import_tagcomplete.py` with a clone of
+- The maintainer script automatically clones
   [a1111-sd-webui-tagcomplete](https://github.com/DominikDoom/a1111-sd-webui-tagcomplete)
-  to refresh the tag list from its CSV files.
+  and refreshes the dataset via `scripts/import_tagcomplete.py`.
 
 ## Setup
 Clone the repository and run the maintainer script to install SDUnity under `/opt/SDUnity` with its own virtual environment:

--- a/maintainer.sh
+++ b/maintainer.sh
@@ -49,6 +49,19 @@ fix_permissions() {
     chmod -R u+rwX,go+rX "$TARGET_DIR"
 }
 
+clone_tagcomplete_repo() {
+    local repo_dir="$TARGET_DIR/tagcomplete"
+    if [ -d "$repo_dir/.git" ]; then
+        git -C "$repo_dir" pull
+    else
+        git clone "https://github.com/DominikDoom/a1111-sd-webui-tagcomplete.git" "$repo_dir"
+    fi
+}
+
+update_tag_dataset() {
+    "$VENV_DIR/bin/python" "$TARGET_DIR/scripts/import_tagcomplete.py" "$TARGET_DIR/tagcomplete" --output "$TARGET_DIR/data/all_tags.csv"
+}
+
 install_sdunity() {
     check_deps
     if [ -d "$TARGET_DIR/.git" ]; then
@@ -59,6 +72,8 @@ install_sdunity() {
     fi
     ensure_venv
     "$VENV_DIR/bin/pip" install -r "$TARGET_DIR/requirements.txt"
+    clone_tagcomplete_repo
+    update_tag_dataset
     fix_permissions
     echo "Installation completed."
 }
@@ -73,6 +88,8 @@ update_sdunity() {
     git pull
     ensure_venv
     "$VENV_DIR/bin/pip" install -r requirements.txt
+    clone_tagcomplete_repo
+    update_tag_dataset
     fix_permissions
     echo "Update completed."
 }

--- a/scripts/import_tagcomplete.py
+++ b/scripts/import_tagcomplete.py
@@ -15,7 +15,12 @@ def main() -> None:
     )
     parser.add_argument(
         "repo",
-        help="Path to the cloned a1111-sd-webui-tagcomplete repository"
+        nargs="?",
+        default=os.environ.get("TAGCOMPLETE_REPO", "data/tagcomplete"),
+        help=(
+            "Path to the cloned a1111-sd-webui-tagcomplete repository. "
+            "Defaults to $TAGCOMPLETE_REPO or 'data/tagcomplete'."
+        ),
     )
     parser.add_argument(
         "--output",


### PR DESCRIPTION
## Summary
- make the tag import script default to a local clone
- automatically clone a1111-sd-webui-tagcomplete and refresh tags via `maintainer.sh`
- update docs for the new automation

## Testing
- `python3 scripts/import_tagcomplete.py --help | head`


------
https://chatgpt.com/codex/tasks/task_e_6851929c9b5c833396101a6a569586fb