### PR TITLE
Improve tag suggestion logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ The UI is split into tabs for generation, model management, a gallery, a Bootcam
 
 ### Tag Suggestions
 - Auto complete prompt tags using a local dataset, directly inside the prompt field.
-- The maintainer script automatically clones
+- Suggestions include fuzzy matches powered by `rapidfuzz`.
+- The maintainer script clones
   [a1111-sd-webui-tagcomplete](https://github.com/DominikDoom/a1111-sd-webui-tagcomplete)
-  and refreshes the dataset via `scripts/import_tagcomplete.py`.
+  and rebuilds the dataset via `scripts/import_tagcomplete.py`.
 
 ## Setup
 Clone the repository and run the maintainer script to install SDUnity under `/opt/SDUnity` with its own virtual environment:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ torch
 transformers
 requests
 peft>=0.6.0
+rapidfuzz


### PR DESCRIPTION
## Summary
- rebuild tag dataset directly from tagcomplete repo
- add fuzzy searching with rapidfuzz
- document the new behaviour

## Testing
- `python -m py_compile sdunity/tags.py`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685194f5cc188333beeaef7f4fd3e8df