### PR TITLE
Enhance tag autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The UI is split into tabs for generation, model management, a gallery, a Bootcam
 - The maintainer script clones
   [a1111-sd-webui-tagcomplete](https://github.com/DominikDoom/a1111-sd-webui-tagcomplete)
   and rebuilds the dataset via `scripts/import_tagcomplete.py`.
+- Press **Tab** while typing to insert the top suggestion without leaving the prompt box.
 
 ## Setup
 Clone the repository and run the maintainer script to install SDUnity under `/opt/SDUnity` with its own virtual environment:

--- a/app.py
+++ b/app.py
@@ -123,13 +123,42 @@ with gr.Blocks(theme=theme, css=css) as demo:
             with gr.Row():
                 with gr.Column(scale=2):
                     with gr.Group(elem_id="prompt_wrapper"):
-                        prompt = gr.Textbox(label="Prompt", lines=2)
+                        prompt = gr.Textbox(label="Prompt", lines=2, elem_id="prompt_box")
                         tag_suggestions = gr.Dropdown(
                             label="",
                             choices=[],
                             visible=False,
                             container=False,
                             elem_id="tag_suggestions",
+                        )
+                        gr.HTML(
+                            """
+                            <script>
+                            document.addEventListener('DOMContentLoaded', () => {
+                                function attach() {
+                                    const prompt = document.querySelector('#prompt_box textarea, #prompt_box input');
+                                    const sugg = document.querySelector('#tag_suggestions select');
+                                    if (!prompt || !sugg) return false;
+                                    prompt.addEventListener('keydown', (e) => {
+                                        if (e.key === 'Tab' && sugg.options.length) {
+                                            e.preventDefault();
+                                            sugg.value = sugg.options[0].value;
+                                            sugg.dispatchEvent(new Event('change', {bubbles: true}));
+                                        }
+                                    });
+                                    return true;
+                                }
+                                if (!attach()) {
+                                    const iv = setInterval(() => {
+                                        if (attach()) clearInterval(iv);
+                                    }, 500);
+                                }
+                            });
+                            </script>
+                            """,
+                            elem_id="prompt_js",
+                            visible=False,
+                            container=False,
                         )
                     negative_prompt = gr.Textbox(label="Negative Prompt", lines=2)
                     preset = gr.Dropdown(


### PR DESCRIPTION
## Summary
- integrate tag suggestions directly with the prompt textbox
- allow `Tab` to insert the first suggestion easily
- document the shortcut

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68519898d9a483339f4f31dd77393fb8