### PR TITLE
Improve prompt enhancement combination

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The UI is split into tabs for generation, model management, a gallery, a Bootcam
 - Smooth step streaming preview (WIP)
 - High‑res fix and denoising strength controls
 - LoRA weight slider
-- Optional GPT‑2 based prompt enhancement (WIP)
+- Optional GPT‑2 based prompt enhancer that augments your prompt
 - NSFW filter toggle
 
 ### Model Manager
@@ -77,6 +77,7 @@ Start the interface with:
 The web UI is available on `http://localhost:7860/` by default. Launch options can be adjusted from the Settings tab or by editing `sdunity/config.py`.
 
 Prompt presets live in `presets.txt`. Set the environment variable `SDUNITY_GPT2_MODEL` to use a different GPT‑2 model for auto enhancement. Install dependencies manually with `pip install -r requirements.txt` if you are not using the maintainer script.
+When enabled, prompt enhancement generates additional quality and detail tags, assembling the final prompt as `[auto quality] + [your prompt] + [auto details] + [preset]`.
 
 ## Maintainer Script
 `maintainer.sh` also handles updates and removal. Run it with `sudo` followed by `install`, `update` or `uninstall`. It manages a virtual environment under `/opt/SDUnity/venv` and requires `git` and `python3`.

--- a/sdunity/generator.py
+++ b/sdunity/generator.py
@@ -102,16 +102,24 @@ def generate_image(
     images_per_batch = max(1, int(images_per_batch))
     batch_count = max(1, int(batch_count))
 
-    if preset:
-        enhancement = presets.PRESETS.get(preset)
-        if enhancement:
-            prompt = f"{prompt}, {enhancement}"
+    enhanced_quality = ""
+    enhanced_details = ""
 
     if auto_enhance:
         try:
-            prompt = enhancer.enhance(prompt)
+            enhanced = enhancer.enhance(prompt)
+            parts = [p.strip() for p in enhanced.split(",") if p.strip()]
+            enhanced_quality = ", ".join(parts[:3])
+            enhanced_details = ", ".join(parts[3:])
         except Exception:
             pass
+
+    preset_text = ""
+    if preset:
+        preset_text = presets.PRESETS.get(preset, "")
+
+    prompt_parts = [enhanced_quality, prompt, enhanced_details, preset_text]
+    prompt = ", ".join([p for p in prompt_parts if p])
 
     pipe = models.get_pipeline(model, progress=progress, category=model_type)
 


### PR DESCRIPTION
## Summary
- keep user prompt when auto enhancing text
- append preset styles last
- document the final prompt schema in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68519c37812083339ca8ef33df95d12f