### PR TITLE
Refine prompt enhancer instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ The web UI is available on `http://localhost:7860/` by default. Launch options c
 
 Prompt presets live in `presets.txt`. Set the environment variable `SDUNITY_GPT2_MODEL` to use a different GPT‑2 model for auto enhancement. Install dependencies manually with `pip install -r requirements.txt` if you are not using the maintainer script.
 When enabled, prompt enhancement generates additional quality and detail tags, assembling the final prompt as `[auto quality] + [your prompt] + [auto details] + [preset]`.
+The enhancer now includes a strict instruction so the language model only returns a
+comma-separated tag list with no extra chatter.
 
 ## Maintainer Script
 `maintainer.sh` also handles updates and removal. Run it with `sudo` followed by `install`, `update` or `uninstall`. It manages a virtual environment under `/opt/SDUnity/venv` and requires `git` and `python3`.

--- a/sdunity/enhancer.py
+++ b/sdunity/enhancer.py
@@ -92,8 +92,10 @@ def enhance(prompt: str, max_tokens: int = 50, seed: int | None = None) -> str:
 
     cleaned = _safe_str(prompt)
     text = (
-        "Take a short image prompt and expand it into a detailed list of descriptive tags.\n"
-        "Only return a comma-separated list of tags in Danbooru style. Do not use full sentences.\n\n"
+        "Always respond in the following format, without exception: "
+        "[auto quality], [enhanced input prompt], [auto-generated detail tags]. "
+        "Do NOT explain, do NOT output anything else. Input is comma-separated.\n"
+        "Expand the given prompt into a detailed list of descriptive tags in Danbooru style.\n\n"
         f"{cleaned}\nTags:"
     )
 


### PR DESCRIPTION
## Summary
- refine the prompt given to the GPT2 enhancer to discourage chatty responses
- update README describing the stricter instruction

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68519eb187c08333a1f851eee1aa8320