### PR TITLE
Fix smooth preview output count

### DIFF
--- a/sdunity/generator.py
+++ b/sdunity/generator.py
@@ -280,7 +280,7 @@ def generate_image(
             frame = preview_queue.get()
             if frame is _STOP:
                 break
-            yield frame, base_seed, gr.update()
+            yield frame, base_seed, gr.update(), gr.update()
         thread.join()
     else:
         _run_generation()


### PR DESCRIPTION
## Summary
- ensure smooth preview emits four outputs for result display

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851ac9a63948333a08a92d72039920b