### PR TITLE
Fix batch seed mismatch

### DIFF
--- a/sdunity/generator.py
+++ b/sdunity/generator.py
@@ -244,7 +244,6 @@ def generate_image(
                 height=int(height),
                 num_inference_steps=int(steps),
                 generator=gens,
-                num_images_per_prompt=int(images_per_batch),
                 guidance_scale=float(guidance_scale),
             )
 


### PR DESCRIPTION
## Summary
- fix the effective batch size when generating multiple images per batch

## Testing
- `python -m py_compile sdunity/generator.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6851bb349f788333a431709e19e6fcb6