### PR TITLE
Fix batch seed mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The UI is split into tabs for generation, model management, a gallery, a Bootcam
 - Control over steps, width, height and guidance scale
 - Clip skip and sampler selection
 - Precision toggle and tiling option
-- Multiple images per batch and batch repetition
+ - Multiple images per batch (parallel generation) and batch repetition
 - Smooth step streaming preview (WIP)
 - High‑res fix and denoising strength controls
 - LoRA weight slider

--- a/sdunity/generator.py
+++ b/sdunity/generator.py
@@ -93,6 +93,10 @@ def generate_image(
         Apply a high resolution pass when enabled.
     auto_enhance : bool
         Improve the prompt using an offline GPT-2 model before generation.
+    images_per_batch : int
+        Number of images generated in parallel for each batch.
+    batch_count : int
+        Number of sequential batches to run.
     """
     if random_seed or seed is None:
         seed = random.randint(0, 2**32 - 1)
@@ -244,7 +248,6 @@ def generate_image(
                 height=int(height),
                 num_inference_steps=int(steps),
                 generator=gens,
-                num_images_per_prompt=int(images_per_batch),
                 guidance_scale=float(guidance_scale),
             )
 


### PR DESCRIPTION
## Summary
- fix the effective batch size when generating multiple images per batch
- clarify batch behavior in README and docstring

## Testing
- `python -m py_compile sdunity/generator.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6851bb349f788333a431709e19e6fcb6