### PR TITLE
Add generator settings presets

### DIFF
--- a/sdunity/__init__.py
+++ b/sdunity/__init__.py
@@ -1,4 +1,15 @@
-from . import presets, models, gallery, generator, config, civitai, bootcamp, tags, wildcards
+from . import (
+    presets,
+    models,
+    gallery,
+    generator,
+    config,
+    civitai,
+    bootcamp,
+    tags,
+    wildcards,
+    settings_presets,
+)
 
 __all__ = [
     "presets",
@@ -10,4 +21,5 @@ __all__ = [
     "bootcamp",
     "tags",
     "wildcards",
+    "settings_presets",
 ]

--- a/sdunity/settings_presets.py
+++ b/sdunity/settings_presets.py
@@ -1,0 +1,35 @@
+import os
+import json
+
+PRESETS_FILE = os.path.join("config", "generator_presets.json")
+
+
+def load_presets(filepath: str = PRESETS_FILE) -> dict:
+    presets = {}
+    if os.path.isfile(filepath):
+        with open(filepath, "r", encoding="utf-8") as f:
+            try:
+                presets = json.load(f)
+            except json.JSONDecodeError:
+                presets = {}
+    return presets
+
+
+def save_presets(presets: dict, filepath: str = PRESETS_FILE) -> None:
+    os.makedirs(os.path.dirname(filepath), exist_ok=True)
+    with open(filepath, "w", encoding="utf-8") as f:
+        json.dump(presets, f, indent=2)
+
+
+PRESETS = load_presets()
+
+
+def add_preset(name: str, data: dict) -> None:
+    PRESETS[name] = data
+    save_presets(PRESETS)
+
+
+def remove_preset(name: str) -> None:
+    if name in PRESETS:
+        del PRESETS[name]
+        save_presets(PRESETS)


### PR DESCRIPTION
## Summary
- add settings_presets module for storing generator presets
- expose module in sdunity package
- add UI for generator settings presets and implement save/load/remove callbacks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851cb4685488333aa47c0ba932c325e