### PR TITLE
Fix preset loading path

### DIFF
--- a/sdunity/config.py
+++ b/sdunity/config.py
@@ -1,11 +1,14 @@
 import os
 import json
 
+# Base directory (project root)
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
 # Directory paths
-MODELS_DIR = "models"
-LORA_DIR = "loras"
-GENERATIONS_DIR = "generations"
-WILDCARDS_DIR = "wildcards"
+MODELS_DIR = os.path.join(BASE_DIR, "models")
+LORA_DIR = os.path.join(BASE_DIR, "loras")
+GENERATIONS_DIR = os.path.join(BASE_DIR, "generations")
+WILDCARDS_DIR = os.path.join(BASE_DIR, "wildcards")
 
 # Ensure output directories exist
 os.makedirs(GENERATIONS_DIR, exist_ok=True)
@@ -46,7 +49,7 @@ GRADIO_LAUNCH_CONFIG = {
 # Settings in this section are persisted to ``config/user_config.json`` so that
 # changes made in the UI survive restarts.
 
-USER_CONFIG_PATH = os.path.join("config", "user_config.json")
+USER_CONFIG_PATH = os.path.join(BASE_DIR, "config", "user_config.json")
 
 # Default values for the user configuration. We include all Gradio launch
 # options so they can be customized from the UI along with the Civitai API key.

--- a/sdunity/settings_presets.py
+++ b/sdunity/settings_presets.py
@@ -1,7 +1,9 @@
 import os
+import os
 import json
+from . import config
 
-PRESETS_FILE = os.path.join("config", "generator_presets.json")
+PRESETS_FILE = os.path.join(config.BASE_DIR, "config", "generator_presets.json")
 
 
 def load_presets(filepath: str = PRESETS_FILE) -> dict:


### PR DESCRIPTION
## Summary
- make config paths absolute to the project root
- ensure settings presets use the new base directory

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851cd4ceb34833389ba43ed2f8154e6