### PR TITLE
Improve Bootcamp tagging UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ The UI is split into tabs for generation, model management, a gallery, a Bootcam
 
 ### Bootcamp (Strongly WIP - Not Functional atm.)
 - Step‑by‑step LoRA trainer with project folders
-- Upload zipped datasets and manage tags without showing images
+- Upload zipped datasets and manage tags with image previews
+- Tags appear as dynamic buttons for bulk operations
+- Separate pages for Training Parameters and Review & Start Training
 - Suggested training parameters based on dataset size
 
 ### Civitai Integration


### PR DESCRIPTION
## Summary
- reworked Bootcamp tagging layout to show grid preview
- allow selecting tags as buttons for bulk edit
- split training step into *Training Parameters* and *Review and Start Training*
- updated README details for Bootcamp

## Testing
- `python -m py_compile sdunity/bootcamp.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_685266bac848833391ed0bbe32559ac2