### PR TITLE
Fix Bootcamp tagging grid

### DIFF
--- a/app.py
+++ b/app.py
@@ -131,12 +131,27 @@ body {
     grid-template-columns: repeat(auto-fill, minmax(128px, 1fr));
     gap: 8px;
 }
+.bc_item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 4px;
+    border: 1px solid #333;
+    border-radius: 4px;
+}
 .bc_item img {
     width: 128px !important;
     height: 128px !important;
     object-fit: cover;
     display: block;
     margin-bottom: 4px;
+}
+.bc_tags {
+    text-align: center;
+}
+.bc_tag_none {
+    color: #888;
+    font-size: 0.8em;
 }
 .bc_tags button {
     margin: 0 2px 2px 0;

--- a/sdunity/bootcamp.py
+++ b/sdunity/bootcamp.py
@@ -127,11 +127,17 @@ def render_tag_grid(proj: BootcampProject) -> str:
     for img in proj.images:
         src = os.path.join(img_dir, img).replace("\\", "/")
         html.append("<div class='bc_item'>")
-        html.append(f"<img src='file/{escape(src)}'/>")
+        html.append(f"<img src='file={escape(src)}'/>")
         html.append("<div class='bc_tags'>")
-        for t in proj.tags.get(img, []):
-            tag = escape(t)
-            html.append(f"<button class='bc_tag' onclick='toggleTag(this)'>{tag}</button>")
+        tags = proj.tags.get(img, [])
+        if tags:
+            for t in tags:
+                tag = escape(t)
+                html.append(
+                    f"<button class='bc_tag' onclick='toggleTag(this)'>{tag}</button>"
+                )
+        else:
+            html.append("<span class='bc_tag_none'>No Tags</span>")
         html.append("</div></div>")
     html.append("</div>")
     html.append(


### PR DESCRIPTION
## Summary
- fix image src path and add placeholder when no tags
- adjust Bootcamp grid CSS for individual image boxes

## Testing
- `python -m py_compile sdunity/bootcamp.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_68526d87152c8333a7721310623697f7