### PR TITLE
Fix Bootcamp image preview links

### DIFF
--- a/sdunity/bootcamp.py
+++ b/sdunity/bootcamp.py
@@ -127,7 +127,7 @@ def render_tag_grid(proj: BootcampProject) -> str:
     for img in proj.images:
         src = os.path.join(img_dir, img).replace("\\", "/")
         html.append("<div class='bc_item'>")
-        html.append(f"<img src='file={escape(src)}'/>")
+        html.append(f"<img src='/file={escape(src)}'/>")
         html.append("<div class='bc_tags'>")
         tags = proj.tags.get(img, [])
         if tags:


### PR DESCRIPTION
## Summary
- ensure Bootcamp grid images use an absolute `/file=` path

## Testing
- `python -m py_compile sdunity/bootcamp.py`


------
https://chatgpt.com/codex/tasks/task_e_6852817221888333b686034f35ad1017