### PR TITLE
Fix Bootcamp image access

### DIFF
--- a/app.py
+++ b/app.py
@@ -941,6 +941,8 @@ with gr.Blocks(theme=theme, css=css) as demo:
 
             with gr.Accordion("Server Options", open=False):
                 for k, default in config.GRADIO_LAUNCH_CONFIG.items():
+                    if k == "allowed_paths":
+                        continue
                     val = config.USER_CONFIG.get(k, default)
                     help_txt = {
                         "server_name": "Network interface to bind",
@@ -976,6 +978,8 @@ with gr.Blocks(theme=theme, css=css) as demo:
                 cfg = {"civitai_api_key": vals[0]}
                 idx = 1
                 for key, default in config.GRADIO_LAUNCH_CONFIG.items():
+                    if key == "allowed_paths":
+                        continue
                     val = vals[idx]
                     idx += 1
                     if isinstance(default, bool):

--- a/sdunity/config.py
+++ b/sdunity/config.py
@@ -27,6 +27,8 @@ os.makedirs(BOOTCAMP_OUTPUT_DIR, exist_ok=True)
 # Central location for default `Blocks.launch` arguments. Adjust values here to
 # change how the Gradio server starts. See the Gradio docs for explanation of
 # each option.
+ALLOWED_PATHS = [GENERATIONS_DIR, BOOTCAMP_DIR]
+
 GRADIO_LAUNCH_CONFIG = {
     # Networking
     "server_name": "0.0.0.0",  # listen on all interfaces
@@ -48,6 +50,7 @@ GRADIO_LAUNCH_CONFIG = {
     # Miscellaneous
     "quiet": False,            # reduce terminal output
     "show_api": True,          # expose REST API docs
+    "allowed_paths": ALLOWED_PATHS,  # directories accessible via /file=
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- allow SDUnity to serve Bootcamp project images by whitelisting directories
- skip the `allowed_paths` entry in the settings UI so users can't change it accidentally

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852858cb20c8333b6c5a433ecd2ca3c