### PR TITLE
Fix Bootcamp image gallery

### DIFF
--- a/app.py
+++ b/app.py
@@ -889,10 +889,9 @@ with gr.Blocks(theme=theme, css=css) as demo:
                         bc_run_autotag = gr.Button("Run Auto-Tagging")
                         bc_autotag_close = gr.Button("Close")
                         bc_autotag_msg = gr.Markdown()
-                    bc_tags_grid = gr.HTML()
+                    bc_gallery = gr.Gallery(label="Images")
                     bc_tags_df = gr.Dataframe(headers=["Image", "Tags"], datatype=["str", "str"], row_count=0, visible=False)
                     bc_save_tags = gr.Button("Save Tags")
-                    bc_selected_tags = gr.Textbox(label="Selected Tags", interactive=False, elem_id="bc_selected_tags")
                     bc_tag_view = gr.Dataframe(headers=["Tag", "Count"], datatype=["str", "int"], interactive=False)
                 with gr.TabItem("5. Training Parameters"):
                     bc_model_select = gr.Radio(["SD 1.5", "SDXL", "Pony"], label="Model", value="SD 1.5")
@@ -1078,8 +1077,8 @@ with gr.Blocks(theme=theme, css=css) as demo:
             return 0, [], "", "Project not found"
         count = bootcamp.import_uploads(proj, uploads)
         rows = [[img, ""] for img in proj.images]
-        html = bootcamp.render_tag_grid(proj)
-        return count, rows, html, f"Imported {count} images"
+        gallery = bootcamp.gallery_paths(proj)
+        return count, rows, gallery, f"Imported {count} images"
 
     def _save_tags_ui(proj_name, rows):
         proj = bootcamp.BootcampProject.load(proj_name)
@@ -1089,8 +1088,8 @@ with gr.Blocks(theme=theme, css=css) as demo:
             proj.tags[img] = [t.strip() for t in str(tag_str).split(",") if t.strip()]
         proj.save()
         data = [[k, v] for k, v in bootcamp.tag_summary(proj).items()]
-        html = bootcamp.render_tag_grid(proj)
-        return data, html
+        gallery = bootcamp.gallery_paths(proj)
+        return data, gallery
 
     def _run_autotag_ui(proj_name, prepend, append, blacklist, max_tags, thresh):
         proj = bootcamp.BootcampProject.load(proj_name)
@@ -1103,8 +1102,8 @@ with gr.Blocks(theme=theme, css=css) as demo:
             proj.tags[img] = pre + auto + app
         proj.save()
         rows = [[img, ", ".join(proj.tags[img])] for img in proj.images]
-        html = bootcamp.render_tag_grid(proj)
-        return rows, html, "Auto tags generated"
+        gallery = bootcamp.gallery_paths(proj)
+        return rows, gallery, "Auto tags generated"
 
     def _export_dataset_ui(proj_name):
         proj = bootcamp.BootcampProject.load(proj_name)
@@ -1117,9 +1116,9 @@ with gr.Blocks(theme=theme, css=css) as demo:
     def _reset_project_ui(proj_name):
         proj = bootcamp.BootcampProject.load(proj_name)
         if proj is None:
-            return [], ""
+            return [], []
         bootcamp.reset_project(proj)
-        return [], ""
+        return [], []
 
     def _show_autotag_ui():
         return gr.update(visible=True)
@@ -1150,12 +1149,12 @@ with gr.Blocks(theme=theme, css=css) as demo:
     bc_upload.click(
         _upload_files_ui,
         inputs=[bc_project, bc_upload_input],
-        outputs=[bc_file_count, bc_tags_df, bc_tags_grid, bc_upload_msg],
+        outputs=[bc_file_count, bc_tags_df, bc_gallery, bc_upload_msg],
     )
     bc_save_tags.click(
         _save_tags_ui,
         inputs=[bc_project, bc_tags_df],
-        outputs=[bc_tag_view, bc_tags_grid],
+        outputs=[bc_tag_view, bc_gallery],
     )
     bc_download_ds.click(
         _export_dataset_ui,
@@ -1165,14 +1164,14 @@ with gr.Blocks(theme=theme, css=css) as demo:
     bc_reset_proj.click(
         _reset_project_ui,
         inputs=bc_project,
-        outputs=[bc_tags_df, bc_tags_grid],
+        outputs=[bc_tags_df, bc_gallery],
     )
     bc_autotag_open.click(_show_autotag_ui, outputs=bc_autotag_popup)
     bc_autotag_close.click(_hide_autotag_ui, outputs=bc_autotag_popup)
     bc_run_autotag.click(
         _run_autotag_ui,
         inputs=[bc_project, bc_prepend, bc_append, bc_blacklist, bc_max_tags, bc_thresh],
-        outputs=[bc_tags_df, bc_tags_grid, bc_autotag_msg],
+        outputs=[bc_tags_df, bc_gallery, bc_autotag_msg],
     )
     bc_model_select.change(
         _review_ui,

--- a/sdunity/bootcamp.py
+++ b/sdunity/bootcamp.py
@@ -120,6 +120,12 @@ def tag_summary(proj: BootcampProject) -> dict[str, int]:
     return counts
 
 
+def gallery_paths(proj: BootcampProject) -> list[str]:
+    """Return absolute image paths for gallery display."""
+    img_dir = os.path.join(proj.path, "images")
+    return [os.path.join(img_dir, img).replace("\\", "/") for img in proj.images]
+
+
 def render_tag_grid(proj: BootcampProject) -> str:
     """Return an HTML grid with image previews and tag buttons."""
     img_dir = os.path.join(proj.path, "images")


### PR DESCRIPTION
## Summary
- replace broken HTML grid with Gradio Gallery
- expose helper function to get gallery image paths
- update callbacks to refresh the new gallery

## Testing
- `pytest -q` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68528771a3a48333ac7eb25e39ea473e