### PR TITLE
Fix Bootcamp tagger gallery

### DIFF
--- a/sdunity/bootcamp.py
+++ b/sdunity/bootcamp.py
@@ -120,12 +120,6 @@ def tag_summary(proj: BootcampProject) -> dict[str, int]:
     return counts
 
 
-def gallery_paths(proj: BootcampProject) -> list[str]:
-    """Return absolute image paths for gallery display."""
-    img_dir = os.path.join(proj.path, "images")
-    return [os.path.join(img_dir, img).replace("\\", "/") for img in proj.images]
-
-
 def render_tag_grid(proj: BootcampProject) -> str:
     """Return an HTML grid with image previews and tag buttons."""
     img_dir = os.path.join(proj.path, "images")


### PR DESCRIPTION
## Summary
- revert tagger grid to custom HTML layout instead of `gr.Gallery`
- remove unused bootcamp `gallery_paths`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68528967c8b883339456420718be408d