### PR TITLE
Add WD14 Tagger backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   - [Gallery](#gallery)
   - [Bootcamp](#bootcamp)
   - [Civitai Integration](#civitai-integration)
+  - [Image Tagger](#image-tagger)
   - [Tag Suggestions](#tag-suggestions)
 - [Setup](#setup)
 - [Maintainer Script](#maintainer-script)
@@ -63,6 +64,9 @@ The UI is split into tabs for generation, model management, a gallery, a Bootcam
   [a1111-sd-webui-tagcomplete](https://github.com/DominikDoom/a1111-sd-webui-tagcomplete)
   and rebuilds the dataset via `scripts/import_tagcomplete.py`.
 - Press **Tab** while typing to insert the top suggestion without leaving the prompt box.
+### Image Tagger
+- Automatically tag anime-style images using the WD14 tagger model
+
 
 ## Setup
 Clone the repository and run the maintainer script to install SDUnity under `/opt/SDUnity` with its own virtual environment:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ transformers
 requests
 peft>=0.6.0
 rapidfuzz
+timm


### PR DESCRIPTION
## Summary
- implement `sdunity/tagger.py` providing a WD14-based anime image tagger
- include `timm` in requirements for model dependencies
- document new Image Tagger feature in README

## Testing
- `python -m py_compile sdunity/tagger.py`
- `python -m py_compile sdunity/*.py`
- `pip install diffusers transformers torch timm`
- attempted to load `WD14Tagger`

------
https://chatgpt.com/codex/tasks/task_e_68529fc6ac6c833391e506f2828bc630