### PR TITLE
Implement WD14 auto tagger and mark bootcamp WIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   - [Generator](#generator)
   - [Model Manager](#model-manager)
   - [Gallery](#gallery)
-  - [Bootcamp](#bootcamp)
+- [Bootcamp](#bootcamp-strongly-wip)
   - [Civitai Integration](#civitai-integration)
   - [Image Tagger](#image-tagger)
   - [Tag Suggestions](#tag-suggestions)
@@ -46,7 +46,7 @@ The UI is split into tabs for generation, model management, a gallery, a Bootcam
 - View metadata such as prompt, model, LoRA and seed
 - Delete unwanted images
 
-### Bootcamp
+### Bootcamp (Strongly WIP)
 Built-in LoRA trainer powered by a lightweight backend.
 - Step‑by‑step LoRA trainer with project folders
 - Upload zipped datasets and manage tags with image previews

--- a/app.py
+++ b/app.py
@@ -1092,16 +1092,22 @@ with gr.Blocks(theme=theme, css=css) as demo:
         html = bootcamp.render_tag_grid(proj)
         return data, html
 
-    def _run_autotag_ui(proj_name, prepend, append, blacklist, max_tags, thresh):
+    def _run_autotag_ui(proj_name, prepend, append, blacklist, max_tags, thresh, progress=gr.Progress()):
         proj = bootcamp.BootcampProject.load(proj_name)
         if proj is None:
             return [], "", "Project not found"
         pre = [t.strip() for t in prepend.split(",") if t.strip()]
         app = [t.strip() for t in append.split(",") if t.strip()]
-        for img in proj.images:
-            auto = [f"tag{i}" for i in range(1, min(int(max_tags), 3) + 1)]
-            proj.tags[img] = pre + auto + app
-        proj.save()
+        bl = {t.strip() for t in blacklist.split(",") if t.strip()}
+        bootcamp.auto_tag_dataset(
+            proj,
+            max_tags=int(max_tags),
+            threshold=float(thresh),
+            prepend=pre,
+            append=app,
+            blacklist=bl,
+            progress=progress,
+        )
         rows = [[img, ", ".join(proj.tags[img])] for img in proj.images]
         html = bootcamp.render_tag_grid(proj)
         return rows, html, "Auto tags generated"


### PR DESCRIPTION
## Summary
- note that Bootcamp is strongly WIP in the README
- add WD14Tagger helper in Bootcamp backend and auto-tag images with it
- wire up the new tagging function with progress handling

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852bd5499fc8333a997c6f2684d8f13