### PR TITLE
Fix WD14Tagger initialization

### DIFF
--- a/sdunity/tagger.py
+++ b/sdunity/tagger.py
@@ -6,6 +6,14 @@ from PIL import Image
 import torch
 from transformers import AutoImageProcessor, AutoModelForImageClassification
 
+try:
+    from timm.models.swin_transformer_v2 import SwinTransformerV2
+    if not hasattr(SwinTransformerV2, "_initialize_weights") and hasattr(SwinTransformerV2, "_init_weights"):
+        SwinTransformerV2._initialize_weights = SwinTransformerV2._init_weights
+except Exception:
+    # ``timm`` might not be installed during documentation builds
+    pass
+
 
 class WD14Tagger:
     """Tag images using the WD14 anime tagging model."""


### PR DESCRIPTION
## Summary
- monkeypatch SwinTransformerV2 to provide missing `_initialize_weights`
- this prevents `AttributeError` when loading the WD14 Auto Tagger

## Testing
- `pytest -q`
- `python - <<'EOF'
from sdunity.tagger import WD14Tagger
print('start')
model=WD14Tagger()
print('labels', len(model.labels))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6852c26d4ec48333b261a6103e46da3f