### PR TITLE
Fix progress check

### DIFF
--- a/sdunity/bootcamp.py
+++ b/sdunity/bootcamp.py
@@ -157,7 +157,7 @@ def auto_tag_dataset(
         if max_tags:
             tags = tags[: int(max_tags)]
         proj.tags[img] = prepend + tags + append
-        if progress:
+        if progress is not None:
             progress((idx, total), desc=f"Tagging {img}")
 
     proj.save()
@@ -233,7 +233,7 @@ def train_lora(
 ) -> Generator[str, None, None]:
     """Train a LoRA model using the custom backend."""
 
-    if progress:
+    if progress is not None:
         progress(0, desc="Initialising trainer")
 
     yield from lora_backend.train_lora(


### PR DESCRIPTION
## Summary
- safely check Bootcamp progress to avoid IndexError

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852c5fb94c0833399eac0fa193f9f69