### PR TITLE
Add lazy loading to bootcamp modules

### DIFF
--- a/app.py
+++ b/app.py
@@ -1085,7 +1085,16 @@ with gr.Blocks(theme=theme, css=css) as demo:
     def _create_project_ui(lora_type, name):
         if not name:
             return None, "Please provide a project name.", False, "### Step 1 of 5", 1
-        proj = bootcamp.create_project(name, lora_type)
+        try:
+            proj = bootcamp.create_project(name, lora_type)
+        except Exception as exc:
+            return (
+                None,
+                f"Error creating project: {exc}",
+                False,
+                "### Step 1 of 5",
+                1,
+            )
         return proj.name, f"Created project `{name}`", True, "### Step 2 of 5", 2
 
     def _upload_files_ui(proj_name, upload_files):

--- a/sdunity/__init__.py
+++ b/sdunity/__init__.py
@@ -1,15 +1,6 @@
-from . import (
-    presets,
-    models,
-    gallery,
-    generator,
-    config,
-    civitai,
-    bootcamp,
-    tags,
-    wildcards,
-    settings_presets,
-)
+"""Lightweight package loader for SDUnity submodules."""
+
+from importlib import import_module
 
 __all__ = [
     "presets",
@@ -23,3 +14,14 @@ __all__ = [
     "wildcards",
     "settings_presets",
 ]
+
+
+def __getattr__(name: str):
+    """Dynamically import submodules on first access.
+
+    This avoids importing heavy dependencies like ``torch`` and
+    ``diffusers`` unless the corresponding modules are actually used.
+    """
+    if name in __all__:
+        return import_module(f"{__name__}.{name}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/sdunity/bootcamp.py
+++ b/sdunity/bootcamp.py
@@ -10,8 +10,7 @@ from html import escape
 
 import gradio as gr
 
-from . import config, lora_backend
-from .tagger import WD14Tagger
+from . import config
 
 
 @dataclass
@@ -43,11 +42,14 @@ class BootcampProject:
         return BootcampProject(**data)
 
 
-_TAGGER: WD14Tagger | None = None
+_TAGGER = None
 
-def _get_tagger() -> WD14Tagger:
+def _get_tagger():
+    """Return a singleton instance of ``WD14Tagger``."""
     global _TAGGER
     if _TAGGER is None:
+        from .tagger import WD14Tagger
+
         _TAGGER = WD14Tagger()
     return _TAGGER
 
@@ -235,6 +237,9 @@ def train_lora(
 
     if progress is not None:
         progress(0, desc="Initialising trainer")
+
+    # Import here to avoid heavy dependencies unless training is run
+    from . import lora_backend
 
     yield from lora_backend.train_lora(
         instance_dir,


### PR DESCRIPTION
## Summary
- avoid eager imports so project creation works without heavy deps
- lazily load sdunity submodules
- lazily load tagger and training backend

## Testing
- `python -m py_compile app.py sdunity/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6852cd44862483338844d41127bf8ef2