### PR TITLE
Set orange-accented dark theme

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,8 +27,8 @@ MODEL_DIR_MAP = {"sd15": "SD15", "sdxl": "SDXL", "ponyxl": "PonyXL"}
 # UI
 # ---------------------------------------------------------------------------
 
-theme = gr.themes.Monochrome(
-    primary_hue="slate",
+theme = gr.themes.Default(
+    primary_hue="orange",
     radius_size=gr.themes.sizes.radius_md,
 ).set(
     body_background_fill="#0d0d0d",


### PR DESCRIPTION
## Summary
- switch to Default gradio theme with primary orange
- keep dark color overrides for UI blocks

## Testing
- `python -m py_compile app.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685943a7a9bc833399079176431660ad