### PR TITLE
Add more samplers and enable random seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ The UI is split into tabs for generation, model management, a gallery and a sett
 ## Features
 ### Generator
 - Prompt and negative prompt inputs
-- Random or fixed seed support
+- Random or fixed seed support (enabled by default)
 - Control over steps, width, height and guidance scale
-- Clip skip and sampler selection
+- Clip skip and sampler selection with more sampler choices
+- Available samplers: Euler, Euler a, DDIM, DPM++ 2M Karras, DPM++ 2M, PNDM, LMS, Heun, DPM++ SDE Karras
 - Precision toggle and tiling option
 - Multiple images per batch (parallel generation) and batch repetition
 - Smooth step streaming preview (WIP)

--- a/app.py
+++ b/app.py
@@ -253,7 +253,7 @@ with gr.Blocks(theme=theme, css=css) as demo:
                         )
                         random_seed_chk = gr.Checkbox(
                             label="Random Seed",
-                            value=False,
+                            value=True,
                             info="Use a new seed for each batch",
                         )
                         steps = gr.Slider(
@@ -325,7 +325,17 @@ with gr.Blocks(theme=theme, css=css) as demo:
                         )
                         scheduler = gr.Dropdown(
                             label="Sampler",
-                            choices=["Euler", "Euler a", "DDIM", "DPM++ 2M Karras"],
+                            choices=[
+                                "Euler",
+                                "Euler a",
+                                "DDIM",
+                                "DPM++ 2M Karras",
+                                "DPM++ 2M",
+                                "PNDM",
+                                "LMS",
+                                "Heun",
+                                "DPM++ SDE Karras",
+                            ],
                             value="Euler",
                         )
                         precision_dd = gr.Dropdown(

--- a/sdunity/generator.py
+++ b/sdunity/generator.py
@@ -11,6 +11,10 @@ from diffusers import (
     EulerDiscreteScheduler,
     DDIMScheduler,
     DPMSolverMultistepScheduler,
+    PNDMScheduler,
+    LMSDiscreteScheduler,
+    HeunDiscreteScheduler,
+    DPMSolverSDEScheduler,
 )
 
 from . import presets, models, gallery, enhancer, wildcards
@@ -143,6 +147,11 @@ def generate_image(
             "Euler a": EulerAncestralDiscreteScheduler,
             "DDIM": DDIMScheduler,
             "DPM++ 2M Karras": DPMSolverMultistepScheduler,
+            "PNDM": PNDMScheduler,
+            "LMS": LMSDiscreteScheduler,
+            "Heun": HeunDiscreteScheduler,
+            "DPM++ SDE Karras": DPMSolverSDEScheduler,
+            "DPM++ 2M": DPMSolverMultistepScheduler,
         }
         sched_cls = sched_map.get(scheduler)
         if sched_cls:


### PR DESCRIPTION
## Summary
- expand available sampler options
- make random seed enabled by default
- document sampler list and default random seed in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68715a5024fc833399a98c902a41f3f1