### PR TITLE
Implement background downloads for model presets

### DIFF
--- a/app.py
+++ b/app.py
@@ -850,8 +850,10 @@ with gr.Blocks(theme=theme, css=css) as demo:
             def _apply_model_preset(name):
                 data = model_loader.PRESETS.get(name)
                 if not data:
-                    return [gr.update() for _ in range(8)]
+                    return [gr.update() for _ in range(8)] + [gr.update(value="", visible=False)]
 
+                msg = model_loader.ensure_preset_assets(name)
+                
                 loras = data.get("loras", [])
                 prompt_val = data.get("prompt", "")
                 neg_val = data.get("negative_prompt", "")
@@ -872,6 +874,7 @@ with gr.Blocks(theme=theme, css=css) as demo:
                     category,
                     gr.update(choices=model_choices, value=model_name),
                     loras,
+                    gr.update(value=msg, visible=bool(msg)),
                 ]
 
 
@@ -1079,6 +1082,7 @@ with gr.Blocks(theme=theme, css=css) as demo:
             model_category,
             model,
             lora,
+            load_status,
         ],
     )
     remove_settings_preset_btn.click(

--- a/sdunity/model_loader.py
+++ b/sdunity/model_loader.py
@@ -1,6 +1,9 @@
 import os
 import json
+import threading
 from typing import Dict, Tuple
+
+from . import config, civitai
 
 # Directory containing model loader presets
 PRESET_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "presets")
@@ -63,9 +66,50 @@ def load_presets(directory: str = PRESET_DIR) -> Dict[str, dict]:
         step = data.get("default_overwrite_step")
         if isinstance(step, int) and step > 0:
             cfg["steps"] = step
+
+        downloads = {}
+        for fname, url in (data.get("checkpoint_downloads") or {}).items():
+            downloads[fname] = (config.MODELS_DIR, url)
+        for fname, url in (data.get("lora_downloads") or {}).items():
+            downloads[fname] = (config.LORA_DIR, url)
+        for fname, url in (data.get("embeddings_downloads") or {}).items():
+            dest = os.path.join(config.BASE_DIR, "embeddings")
+            downloads[fname] = (dest, url)
+        if downloads:
+            cfg["downloads"] = downloads
         presets[os.path.splitext(fname)[0]] = cfg
     return presets
 
 
 # Load presets at import time
 PRESETS = load_presets()
+
+
+def _file_exists(directory: str, name: str) -> bool:
+    for root, _dirs, files in os.walk(directory):
+        if name in files:
+            return True
+    return False
+
+
+def ensure_preset_assets(name: str) -> str:
+    """Download missing files referenced by a preset in the background."""
+    data = PRESETS.get(name)
+    if not data:
+        return ""
+    downloads = data.get("downloads") or {}
+    messages = []
+
+    for fname, (dest, url) in downloads.items():
+        if not _file_exists(dest, fname):
+
+            def _dl(u=url, d=dest, f=fname):
+                try:
+                    civitai.download_model(u, d)
+                except Exception as e:  # pragma: no cover - network
+                    print(f"Download failed for {f}:", e)
+
+            threading.Thread(target=_dl, daemon=True).start()
+            messages.append(f"Downloading {fname} in background...")
+
+    return "\n".join(messages)


### PR DESCRIPTION
## Summary
- extend model loader to read download links from preset files
- add helper to download missing models in the background
- inform users when preset models trigger a download

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6871614046b483338c1443db774d6fd4